### PR TITLE
EVM: fix overflow behaviour of addmod and mulmod

### DIFF
--- a/src/Meadow.EVM/EVM/Instructions/Arithmetic/InstructionAddMod.cs
+++ b/src/Meadow.EVM/EVM/Instructions/Arithmetic/InstructionAddMod.cs
@@ -24,7 +24,7 @@ namespace Meadow.EVM.EVM.Instructions.Arithmetic
             BigInteger a = Stack.Pop();
             BigInteger b = Stack.Pop();
             BigInteger c = Stack.Pop();
-            BigInteger result = c == 0 ? 0 : (a + b).CapOverflow() % c;
+            BigInteger result = c == 0 ? 0 : ((a + b) % c).CapOverflow();
 
             // Push the result onto the stack.
             Stack.Push(result);

--- a/src/Meadow.EVM/EVM/Instructions/Arithmetic/InstructionMultiplyMod.cs
+++ b/src/Meadow.EVM/EVM/Instructions/Arithmetic/InstructionMultiplyMod.cs
@@ -24,7 +24,7 @@ namespace Meadow.EVM.EVM.Instructions.Arithmetic
             BigInteger a = Stack.Pop();
             BigInteger b = Stack.Pop();
             BigInteger c = Stack.Pop();
-            BigInteger result = c == 0 ? 0 : (a * b).CapOverflow() % c;
+            BigInteger result = c == 0 ? 0 : ((a * b) % c).CapOverflow();
 
             // Push the result onto the stack.
             Stack.Push(result);

--- a/src/Meadow.UnitTestTemplate.Test/Contracts/PrecompilesContract.sol
+++ b/src/Meadow.UnitTestTemplate.Test/Contracts/PrecompilesContract.sol
@@ -22,6 +22,15 @@ contract PrecompilesContract {
 	function testECRecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) public returns (address from) {
 		return ecrecover(hash, v, r, s);
 	}
+
+    function testAddMod(uint x, uint y, uint z) public pure returns (uint) {
+        return addmod(x, y, z);
+    }
+
+    function testMulMod(uint x, uint y, uint z) public pure returns (uint) {
+        return mulmod(x, y, z);
+    }
+
     function testIdentity(bytes memory input) public returns(bytes memory)
     {
         // Initialize our output array


### PR DESCRIPTION
As per the Ethereum yellow paper, the intermediate results of the `addmod` and `mulmod` instructions should not be truncated to 256-bits before performing the modulo operation. This commit performs the truncation after the modulo.

The previous implementation resulted in incorrect results in many cases involving large numbers, for example:

```
mulmod(2^255, 3, 5) = 3 (old implementation)

mulmod(2^255, 3, 5) = 4 (new implementation, correct)
```